### PR TITLE
Parameterize url

### DIFF
--- a/manifests/deploy.yaml
+++ b/manifests/deploy.yaml
@@ -50,6 +50,12 @@ spec:
               secretKeyRef:
                 name: jwt
                 key: issuer
+          - name: STOCKQUOTE_URL
+            valueFrom:
+              secretKeyRef:
+                name: stockquote
+                key: url
+                optional: true
         ports:
           - containerPort: 9080
           - containerPort: 9443

--- a/src/main/java/com/ibm/hybrid/cloud/sample/portfolio/StockQuote.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/portfolio/StockQuote.java
@@ -79,6 +79,18 @@ public class StockQuote extends Application {
 	private @Inject @RestClient APIConnectClient apiConnectClient;
 	private @Inject @RestClient IEXClient iexClient;
 
+	// Override stock quote rest client URL if secret is configured to provide URL
+	static {
+	    String mpUrlPropName = APIConnectClient.class.getName() + "/mp-rest/url";
+    	String stockQuoteURL = System.getenv("STOCKQUOTE_URL");
+		if (stockQuoteURL != null && !stockQuoteURL.isEmpty()) {
+		    logger.info("Using API Connect URL from secret: " + stockQuoteURL);
+			System.setProperty(mpUrlPropName, stockQuoteURL);
+		} else {
+		    logger.info("Using API Connect URL from configuration: " + System.getProperty(mpUrlPropName));
+		}
+	}
+
 	public static void main(String[] args) {
 		try {
 			if (args.length > 0) {

--- a/src/main/java/com/ibm/hybrid/cloud/sample/portfolio/StockQuote.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/portfolio/StockQuote.java
@@ -81,13 +81,13 @@ public class StockQuote extends Application {
 
 	// Override API Connect Client URL if secret is configured to provide URL
 	static {
-	    String mpUrlPropName = APIConnectClient.class.getName() + "/mp-rest/url";
+		String mpUrlPropName = APIConnectClient.class.getName() + "/mp-rest/url";
 		String stockQuoteURL = System.getenv("STOCKQUOTE_URL");
 		if (stockQuoteURL != null && !stockQuoteURL.isEmpty()) {
-		    logger.info("Using API Connect URL from secret: " + stockQuoteURL);
+			logger.info("Using API Connect URL from secret: " + stockQuoteURL);
 			System.setProperty(mpUrlPropName, stockQuoteURL);
 		} else {
-		    logger.info("Using API Connect URL from configuration: " + System.getProperty(mpUrlPropName));
+			logger.info("Using API Connect URL from configuration: " + System.getProperty(mpUrlPropName));
 		}
 	}
 

--- a/src/main/java/com/ibm/hybrid/cloud/sample/portfolio/StockQuote.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/portfolio/StockQuote.java
@@ -79,10 +79,10 @@ public class StockQuote extends Application {
 	private @Inject @RestClient APIConnectClient apiConnectClient;
 	private @Inject @RestClient IEXClient iexClient;
 
-	// Override stock quote rest client URL if secret is configured to provide URL
+	// Override API Connect Client URL if secret is configured to provide URL
 	static {
 	    String mpUrlPropName = APIConnectClient.class.getName() + "/mp-rest/url";
-    	String stockQuoteURL = System.getenv("STOCKQUOTE_URL");
+		String stockQuoteURL = System.getenv("STOCKQUOTE_URL");
 		if (stockQuoteURL != null && !stockQuoteURL.isEmpty()) {
 		    logger.info("Using API Connect URL from secret: " + stockQuoteURL);
 			System.setProperty(mpUrlPropName, stockQuoteURL);


### PR DESCRIPTION
This PR adds support for an optional secret through which someone can configure the URL for the API Connect endpoint.  This avoids having to rebuild the project to update the URL in jvm.options.