### PR TITLE
Add redis pool configuration to prevent stale connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>3.7.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/stockquote/StockQuote.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/stockquote/StockQuote.java
@@ -176,8 +176,7 @@ public class StockQuote extends Application {
 				jedisPoolConfig.setTimeBetweenEvictionRuns(Duration.ofSeconds(30));
 				jedisPoolConfig.setNumTestsPerEvictionRun(-1); // test all connections
 
-				jedisPool = new JedisPool(jedisURI);
-
+				jedisPool = new JedisPool(jedisPoolConfig, jedisURI);
 				if (jedisPool != null) logger.info("Redis pool initialized successfully!");
 			} catch (Throwable t) {
 				initializationFailed = true; //so we don't retry the above thousands of times and log big stack traces each time

--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/stockquote/StockQuote.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/stockquote/StockQuote.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -63,6 +64,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 //Jedis (Java for Redis)
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
 
 
 @ApplicationPath("/")
@@ -166,6 +168,14 @@ public class StockQuote extends Application {
 				String redis_url = System.getenv("REDIS_URL");
 				URI jedisURI = new URI(redis_url);
 				logger.info("Initializing Redis pool using URL: "+redis_url);
+				// @rtclauss Add connection pool configuration to combat potentially stale connections
+				JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
+				jedisPoolConfig.setTestOnBorrow(true);
+				jedisPoolConfig.setTestWhileIdle(true);
+				jedisPoolConfig.setMinEvictableIdleTime(Duration.ofSeconds(60));
+				jedisPoolConfig.setTimeBetweenEvictionRuns(Duration.ofSeconds(30));
+				jedisPoolConfig.setNumTestsPerEvictionRun(-1); // test all connections
+
 				jedisPool = new JedisPool(jedisURI);
 				if (jedisPool != null) logger.info("Redis pool initialized successfully!");
 			} catch (Throwable t) {


### PR DESCRIPTION
This PR adds more connection pool configuration to Jedis. This allows us to:

- Increase the number of connections to Redis while maintaining a minimum amount for bursting
- Test and evict failed connections from the pool
- Block when the pool is fully utilized
- Throw an exception if the pool is utilized for too long
- Trace the state of the connection pool at FINEST trace specification

There is also a bump to `jedis` version `4.0.1`.