### PR TITLE
Enable updating Gitops repo for AWS

### DIFF
--- a/.github/workflows/build-test-push-aws-ecr.yml
+++ b/.github/workflows/build-test-push-aws-ecr.yml
@@ -110,3 +110,49 @@ jobs:
           --build-arg GITHUB_REF="$GITHUB_REF" .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+  update-gitops-repo:
+    name: Publish image updates to gitops repo
+    runs-on: ubuntu-latest
+    needs: [setup-build-publish-deploy]
+    steps:
+
+      # Checkout gitops repo
+      - name: Checkout gitops repo
+        uses: actions/checkout@v2
+        with:
+          repository: ${{env.GITOPS_REPO}}
+          path: gitops
+          token: ${{secrets.GITOPS_TOKEN}}
+
+      # Update application
+      - name: Upate application
+        run: |
+          set -x
+          set +e
+          ls -la
+          ls -la gitops
+          cd gitops
+          
+          ## update manifests to new image and tag
+          APP_IMAGE="$ECR_REGISTRY/$ECR_REPOSITORY"
+          VERSION="$GITHUB_SHA"
+          echo "image-registry-path: ${{needs.setup-build-publish-deploy.image-registry-path}}"
+          echo "${APP_IMAGE}"
+          echo "${VERSION}"
+          echo "print yq version"
+          yq --version
+          # yq w -i "${GITOPS_DIR}/stocktrader-aws-eks-cr.yml" spec.stock-quote.image.repository "${APP_IMAGE}"
+          yq e ".spec.stock-quote.image.repository = \"$APP_IMAGE\"" -i "${GITOPS_DIR}/stocktrader-aws-eks-cr.yml"
+          # yq w -i "${GITOPS_DIR}/stocktrader-aws-eks-cr.yml" spec.stock-quote.image.tag "${VERSION}"
+          yq e ".spec.stock-quote.image.tag = \"$VERSION\"" -i "${GITOPS_DIR}/stocktrader-aws-eks-cr.yml"
+          cat "${GITOPS_DIR}/stocktrader-aws-eks-cr.yml"          
+          if [[ $(git status -s | wc -l) -eq 0 ]]; then
+            echo "No changes"
+            exit 0
+          fi
+          git add "${GITOPS_DIR}/"
+          git config --global user.name 'GH Actions'
+          git config --global user.email 'github-actions@users.noreply.github.com'        
+          git commit -am "Updates ${APP_NAME} to ${VERSION}"   
+          git push https://$GITOPS_USERNAME:$GITOPS_TOKEN@github.com/$GITOPS_REPO 


### PR DESCRIPTION
Now, when there is a commit to `stock-quote`, the corresponding image tag in the [stocktrader-gitops](https://github.com/IBMStockTrader/stocktrader-gitops) repository's StockTrader CustomResource is also updated and applied to our AWS EKS GitOps cluster.